### PR TITLE
Setup and startup scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,21 @@ RUN apt-get update; apt-get -y install libapreq2-dev apache2-mpm-prefork libapac
 RUN curl -L http://cpanmin.us | perl - App::cpanminus
 RUN cpanm -n -L $LJHOME/extlib/ DateTime::TimeZone Business::CreditCard Cache::Memcached Captcha::reCAPTCHA Class::Accessor Class::Autouse Class::Data::Inheritable Class::Trigger Danga::Socket Data::ObjectDriver DateTime Digest::HMAC_SHA1 Digest::SHA1 Digest::SHA256 File::Type GTop Gearman::Client GnuPG::Interface Hash::MultiValue IO::AIO IO::WrapTie IP::Country::Fast Image::Size LWPx::ParanoidAgent MIME::Lite MIME::Words Mail::GnuPG MogileFS::Client Net::DNS Net::PubSubHubbub::Publisher Proc::ProcessTable RPC::XML SOAP::Lite String::CRC32 Sys::Syscall Template Text::Markdown Text::vCard TheSchwartz TheSchwartz::Worker::PubSubHubbubPublish TheSchwartz::Worker::SendEmail URI::Fetch Unicode::CheckUTF8 Unicode::MapUTF8 XML::Atom XML::RSS XMLRPC::Lite YAML MogileFS::Server MogileFS::Utils Gearman::Server
 
+ADD scripts/setup-dw.sh /opt/
+
 # Now that we have the base setup, kick off the DW configuration.
-RUN curl https://raw.github.com/xb95/dw-docker/master/scripts/setup-dw.sh | bash
+RUN /usr/bin/mysqld_safe & \
+    sleep 5s && \
+    bash /opt/setup-dw.sh
 
 # Reset the APT configuration.
 RUN cp $LJHOME/ext/dw-docker/files/sources.list /etc/apt/sources.list; apt-get update
+
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+
+EXPOSE 80
+
+ADD scripts/startup.sh /opt/startup.sh
+ENTRYPOINT ["/opt/startup.sh"]

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+service mysql start
+/usr/sbin/apache2
+
+/bin/bash -i


### PR DESCRIPTION
- Instead of fetching the setup script using curl, use the locally
  available script
- Create a startup script which starts mysql and apache, and then opens
  up an interactive bash shell so that the docker container won't spin
  down. We can also do this using `apache2 -D FOREGROUND`, but using
  bash instead lets us connect to the container again to see what's
  going on
- RUN mysql with the setup script, because at this point we have no
  mysql daemon to connect to
- Add environment variables/setup for apache
